### PR TITLE
fix(mal): preserve MAL IDs silently omitted by API

### DIFF
--- a/cmd/shinkrodb/migrate.go
+++ b/cmd/shinkrodb/migrate.go
@@ -61,7 +61,7 @@ After migration, you can use the new efficient cache system.`,
 
 			// Fetch MAL IDs first (needed for release dates/types in migration)
 			malSvc := mal.NewService(log, cfg, animeRepo, paths.MalIDPath, paths.AniDBPath)
-			if err := malSvc.GetAnimeIDs(cmd.Context(), cacheRepo); err != nil {
+			if _, err := malSvc.GetAnimeIDs(cmd.Context(), cacheRepo); err != nil {
 				return fmt.Errorf("failed to get MAL IDs: %w", err)
 			}
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -105,7 +105,8 @@ func (a *App) Run(rootPath string) (err error) {
 	cacheRepo := database.NewCacheRepo(a.log, db)
 
 	// Get MAL IDs and update mal_cache
-	if err := a.malService.GetAnimeIDs(ctx, cacheRepo); err != nil {
+	preservedMALIDs, err := a.malService.GetAnimeIDs(ctx, cacheRepo)
+	if err != nil {
 		return fmt.Errorf("failed to get MAL IDs: %w", err)
 	}
 
@@ -143,9 +144,10 @@ func (a *App) Run(rootPath string) (err error) {
 	}
 
 	// Calculate and log final statistics
-	stats := calculateStatistics(deduped, dupeCount)
+	stats := calculateStatistics(deduped, dupeCount, preservedMALIDs)
 	a.log.Info().
 		Int("total_mal_ids", stats.TotalMALIDs).
+		Int("preserved_mal_ids", stats.PreservedMALIDs).
 		Int("mal_ids_with_anidb", stats.MALIDsWithAniDB).
 		Int("mal_ids_without_anidb", stats.TotalMALIDs-stats.MALIDsWithAniDB).
 		Int("total_movies", stats.TotalMovies).
@@ -168,10 +170,11 @@ func (a *App) Run(rootPath string) (err error) {
 }
 
 // calculateStatistics calculates comprehensive statistics from the final anime list
-func calculateStatistics(animeList []domain.Anime, dupeCount int) domain.Statistics {
+func calculateStatistics(animeList []domain.Anime, dupeCount, preservedMALIDs int) domain.Statistics {
 	stats := domain.Statistics{
-		TotalMALIDs: len(animeList),
-		DupeCount:   dupeCount,
+		TotalMALIDs:     len(animeList),
+		DupeCount:       dupeCount,
+		PreservedMALIDs: preservedMALIDs,
 	}
 
 	for _, anime := range animeList {

--- a/internal/domain/notification.go
+++ b/internal/domain/notification.go
@@ -22,6 +22,7 @@ type Statistics struct {
 	AniDBCoveragePercent  float64
 	TMDBCoveragePercent   float64
 	TVDBCoveragePercent   float64
-	DupeCount            int
+	DupeCount             int
+	PreservedMALIDs       int
 }
 

--- a/internal/mal/service.go
+++ b/internal/mal/service.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Service interface {
-	GetAnimeIDs(ctx context.Context, cacheRepo domain.CacheRepo) error
+	GetAnimeIDs(ctx context.Context, cacheRepo domain.CacheRepo) (int, error)
 	ScrapeAniDBIDs(ctx context.Context, cacheRepo domain.CacheRepo) error
 }
 
@@ -80,7 +80,7 @@ func NewService(log zerolog.Logger, config *domain.Config, animeRepo domain.Anim
 	}
 }
 
-func (s *service) GetAnimeIDs(ctx context.Context, cacheRepo domain.CacheRepo) error {
+func (s *service) GetAnimeIDs(ctx context.Context, cacheRepo domain.CacheRepo) (int, error) {
 	s.log.Info().Msg("Getting current ids from myanimelist..")
 	c := &http.Client{
 		Transport: &clientIDTransport{ClientID: s.config.MalClientID},
@@ -89,17 +89,38 @@ func (s *service) GetAnimeIDs(ctx context.Context, cacheRepo domain.CacheRepo) e
 	a := []domain.Anime{}
 	next, err := s.storeAnimeID(ctx, c, "https://api.myanimelist.net/v2/anime/ranking?ranking_type=all&limit=500&fields={media_type,start_date,alternative_titles}", &a)
 	if err != nil {
-		return errors.Wrap(err, "failed to fetch initial MAL IDs")
+		return 0, errors.Wrap(err, "failed to fetch initial MAL IDs")
 	}
 
 	for {
 		if next != "" {
 			next, err = s.storeAnimeID(ctx, c, next, &a)
 			if err != nil {
-				return errors.Wrap(err, "failed to fetch MAL IDs")
+				return 0, errors.Wrap(err, "failed to fetch MAL IDs")
 			}
 		} else {
 			break
+		}
+	}
+
+	// Merge with existing malid.json to preserve any IDs the API may have omitted.
+	// The MAL ranking API sometimes silently excludes entries, which would cause
+	// previously known IDs to disappear from all downstream files.
+	preserved := 0
+	existing, err := s.animeRepo.Get(ctx, s.malIDPath)
+	if err == nil && len(existing) > 0 {
+		newIDs := make(map[int]bool, len(a))
+		for _, anime := range a {
+			newIDs[anime.MalID] = true
+		}
+		for _, anime := range existing {
+			if !newIDs[anime.MalID] {
+				a = append(a, anime)
+				preserved++
+			}
+		}
+		if preserved > 0 {
+			s.log.Warn().Int("count", preserved).Msg("Preserved MAL IDs missing from API response")
 		}
 	}
 
@@ -119,11 +140,11 @@ func (s *service) GetAnimeIDs(ctx context.Context, cacheRepo domain.CacheRepo) e
 	}
 
 	if err := s.animeRepo.Store(ctx, s.malIDPath, a); err != nil {
-		return errors.Wrap(err, "failed to store MAL IDs")
+		return 0, errors.Wrap(err, "failed to store MAL IDs")
 	}
 	s.log.Info().Str("path", string(s.malIDPath)).Msg("Stored malids")
 
-	return nil
+	return preserved, nil
 }
 
 func (s *service) storeAnimeID(ctx context.Context, c *http.Client, url string, a *[]domain.Anime) (string, error) {

--- a/internal/notification/discord.go
+++ b/internal/notification/discord.go
@@ -42,33 +42,7 @@ func (s *DiscordService) SendSuccess(ctx context.Context, stats domain.Statistic
 		Description: "Database update completed successfully",
 		Color:       0x00ff00, // Green
 		Timestamp:   time.Now().Format(time.RFC3339),
-		Fields: []discordField{
-			{
-				Name:   "Total MAL IDs",
-				Value:  fmt.Sprintf("%d", stats.TotalMALIDs),
-				Inline: true,
-			},
-			{
-				Name:   "AniDB Coverage",
-				Value:  fmt.Sprintf("%d (%.1f%%)", stats.MALIDsWithAniDB, stats.AniDBCoveragePercent),
-				Inline: true,
-			},
-			{
-				Name:   "Movies",
-				Value:  fmt.Sprintf("%d total, %d with TMDB (%.1f%%)", stats.TotalMovies, stats.MoviesWithTMDB, stats.TMDBCoveragePercent),
-				Inline: false,
-			},
-			{
-				Name:   "TV Shows",
-				Value:  fmt.Sprintf("%d total, %d with TVDB (%.1f%%)", stats.TotalTVShows, stats.TVShowsWithTVDB, stats.TVDBCoveragePercent),
-				Inline: false,
-			},
-			{
-				Name:   "Duplicates Removed",
-				Value:  fmt.Sprintf("%d", stats.DupeCount),
-				Inline: true,
-			},
-		},
+		Fields: s.buildSuccessFields(stats),
 	}
 
 	payload := discordWebhook{
@@ -76,6 +50,44 @@ func (s *DiscordService) SendSuccess(ctx context.Context, stats domain.Statistic
 	}
 
 	return s.sendWebhook(ctx, payload)
+}
+
+func (s *DiscordService) buildSuccessFields(stats domain.Statistics) []discordField {
+	fields := []discordField{
+		{
+			Name:   "Total MAL IDs",
+			Value:  fmt.Sprintf("%d", stats.TotalMALIDs),
+			Inline: true,
+		},
+		{
+			Name:   "AniDB Coverage",
+			Value:  fmt.Sprintf("%d (%.1f%%)", stats.MALIDsWithAniDB, stats.AniDBCoveragePercent),
+			Inline: true,
+		},
+		{
+			Name:   "Movies",
+			Value:  fmt.Sprintf("%d total, %d with TMDB (%.1f%%)", stats.TotalMovies, stats.MoviesWithTMDB, stats.TMDBCoveragePercent),
+			Inline: false,
+		},
+		{
+			Name:   "TV Shows",
+			Value:  fmt.Sprintf("%d total, %d with TVDB (%.1f%%)", stats.TotalTVShows, stats.TVShowsWithTVDB, stats.TVDBCoveragePercent),
+			Inline: false,
+		},
+		{
+			Name:   "Duplicates Removed",
+			Value:  fmt.Sprintf("%d", stats.DupeCount),
+			Inline: true,
+		},
+	}
+	if stats.PreservedMALIDs > 0 {
+		fields = append(fields, discordField{
+			Name:   "Preserved MAL IDs (API omission)",
+			Value:  fmt.Sprintf("%d", stats.PreservedMALIDs),
+			Inline: true,
+		})
+	}
+	return fields
 }
 
 // SendError sends an error notification with error details


### PR DESCRIPTION
## Problem

The MAL ranking API (`ranking_type=all`) sometimes silently excludes known anime entries from its response. Because `GetAnimeIDs()` completely replaces `malid.json` with each run, any omitted IDs are lost from all downstream files — including `for-shinkro.json`.

## Solution

After fetching all pages from the MAL API, `GetAnimeIDs()` now reads the existing `malid.json` and re-adds any entries whose MAL ID is absent from the new API response. On first run (no existing file) the merge step is skipped transparently.

The preserved count is:
- Returned from `GetAnimeIDs()` (signature changed from `error` to `(int, error)`)
- Added to `Statistics` as `PreservedMALIDs`
- Logged at `WARN` level in the final statistics
- Shown as a Discord notification field **only when non-zero**, keeping normal run notifications clean

## Files changed

- `internal/mal/service.go` — merge logic + updated return signature
- `internal/domain/notification.go` — `PreservedMALIDs` field on `Statistics`
- `internal/app/app.go` — capture count, pass to stats, log it
- `internal/notification/discord.go` — conditional Discord field via `buildSuccessFields()`
- `cmd/shinkrodb/migrate.go` — updated call site for new signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)