### PR TITLE
chore: migrate module path and URLs to shinkro org

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,4 +66,4 @@ changelog:
 release:
   prerelease: auto
   footer: |
-    **Full Changelog**: https://github.com/varoOP/shinkrodb/compare/{{ .PreviousTag }}...{{ .Tag }}
+    **Full Changelog**: https://github.com/shinkro/shinkrodb/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/cmd/shinkrodb/format.go
+++ b/cmd/shinkrodb/format.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/varoOP/shinkrodb/internal/app"
+	"github.com/shinkro/shinkrodb/internal/app"
 )
 
 var formatCmd = &cobra.Command{

--- a/cmd/shinkrodb/genmap.go
+++ b/cmd/shinkrodb/genmap.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/varoOP/shinkrodb/internal/app"
+	"github.com/shinkro/shinkrodb/internal/app"
 )
 
 var genmapCmd = &cobra.Command{

--- a/cmd/shinkrodb/migrate.go
+++ b/cmd/shinkrodb/migrate.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/varoOP/shinkrodb/internal/cache"
-	"github.com/varoOP/shinkrodb/internal/config"
-	"github.com/varoOP/shinkrodb/internal/database"
-	"github.com/varoOP/shinkrodb/internal/domain"
-	"github.com/varoOP/shinkrodb/internal/logger"
-	"github.com/varoOP/shinkrodb/internal/mal"
-	"github.com/varoOP/shinkrodb/internal/repository"
+	"github.com/shinkro/shinkrodb/internal/cache"
+	"github.com/shinkro/shinkrodb/internal/config"
+	"github.com/shinkro/shinkrodb/internal/database"
+	"github.com/shinkro/shinkrodb/internal/domain"
+	"github.com/shinkro/shinkrodb/internal/logger"
+	"github.com/shinkro/shinkrodb/internal/mal"
+	"github.com/shinkro/shinkrodb/internal/repository"
 )
 
 var migrateCmd = &cobra.Command{

--- a/cmd/shinkrodb/run.go
+++ b/cmd/shinkrodb/run.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/varoOP/shinkrodb/internal/app"
+	"github.com/shinkro/shinkrodb/internal/app"
 )
 
 var runCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/varoOP/shinkrodb
+module github.com/shinkro/shinkrodb
 
 go 1.25.5
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,17 +6,17 @@ import (
 	"path/filepath"
 
 	"github.com/rs/zerolog"
-	"github.com/varoOP/shinkrodb/internal/config"
-	"github.com/varoOP/shinkrodb/internal/database"
-	"github.com/varoOP/shinkrodb/internal/dedupe"
-	"github.com/varoOP/shinkrodb/internal/domain"
-	"github.com/varoOP/shinkrodb/internal/format"
-	"github.com/varoOP/shinkrodb/internal/logger"
-	"github.com/varoOP/shinkrodb/internal/mal"
-	"github.com/varoOP/shinkrodb/internal/notification"
-	"github.com/varoOP/shinkrodb/internal/repository"
-	"github.com/varoOP/shinkrodb/internal/tmdb"
-	"github.com/varoOP/shinkrodb/internal/tvdb"
+	"github.com/shinkro/shinkrodb/internal/config"
+	"github.com/shinkro/shinkrodb/internal/database"
+	"github.com/shinkro/shinkrodb/internal/dedupe"
+	"github.com/shinkro/shinkrodb/internal/domain"
+	"github.com/shinkro/shinkrodb/internal/format"
+	"github.com/shinkro/shinkrodb/internal/logger"
+	"github.com/shinkro/shinkrodb/internal/mal"
+	"github.com/shinkro/shinkrodb/internal/notification"
+	"github.com/shinkro/shinkrodb/internal/repository"
+	"github.com/shinkro/shinkrodb/internal/tmdb"
+	"github.com/shinkro/shinkrodb/internal/tvdb"
 )
 
 // App represents the main application with all dependencies initialized

--- a/internal/cache/migrate.go
+++ b/internal/cache/migrate.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"github.com/varoOP/shinkrodb/internal/database"
-	"github.com/varoOP/shinkrodb/internal/domain"
+	"github.com/shinkro/shinkrodb/internal/database"
+	"github.com/shinkro/shinkrodb/internal/domain"
 	"golang.org/x/net/html"
 )
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/viper"
-	"github.com/varoOP/shinkrodb/internal/domain"
+	"github.com/shinkro/shinkrodb/internal/domain"
 )
 
 // Load loads configuration from multiple sources:

--- a/internal/database/cache.go
+++ b/internal/database/cache.go
@@ -7,7 +7,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"github.com/varoOP/shinkrodb/internal/domain"
+	"github.com/shinkro/shinkrodb/internal/domain"
 )
 
 // CacheRepo implements domain.CacheRepo interface

--- a/internal/dedupe/service.go
+++ b/internal/dedupe/service.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"github.com/varoOP/shinkrodb/internal/domain"
+	"github.com/shinkro/shinkrodb/internal/domain"
 )
 
 type Service interface {

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/varoOP/shinkrodb/internal/domain"
+	"github.com/shinkro/shinkrodb/internal/domain"
 )
 
 func FormatTMDB(rootPath string, mappingRepo domain.MappingRepository) error {

--- a/internal/mal/service.go
+++ b/internal/mal/service.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gocolly/colly/extensions"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"github.com/varoOP/shinkrodb/internal/domain"
+	"github.com/shinkro/shinkrodb/internal/domain"
 )
 
 type Service interface {

--- a/internal/notification/discord.go
+++ b/internal/notification/discord.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"github.com/varoOP/shinkrodb/internal/domain"
+	"github.com/shinkro/shinkrodb/internal/domain"
 )
 
 // DiscordService implements NotificationService for Discord webhooks

--- a/internal/notification/service.go
+++ b/internal/notification/service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/rs/zerolog"
-	"github.com/varoOP/shinkrodb/internal/domain"
+	"github.com/shinkro/shinkrodb/internal/domain"
 )
 
 // Service is a composite notification service that can send notifications

--- a/internal/repository/file.go
+++ b/internal/repository/file.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog"
-	"github.com/varoOP/shinkrodb/internal/domain"
+	"github.com/shinkro/shinkrodb/internal/domain"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/tmdb/service.go
+++ b/internal/tmdb/service.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"github.com/varoOP/shinkrodb/internal/domain"
-	"github.com/varoOP/shinkrodb/pkg/animelist"
+	"github.com/shinkro/shinkrodb/internal/domain"
+	"github.com/shinkro/shinkrodb/pkg/animelist"
 )
 
 type Service interface {

--- a/internal/tvdb/service.go
+++ b/internal/tvdb/service.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"github.com/varoOP/shinkrodb/internal/domain"
-	"github.com/varoOP/shinkrodb/pkg/animelist"
+	"github.com/shinkro/shinkrodb/internal/domain"
+	"github.com/shinkro/shinkrodb/pkg/animelist"
 )
 
 type Service interface {


### PR DESCRIPTION
## Summary

Updates all references from `github.com/varoOP/shinkrodb` to `github.com/shinkro/shinkrodb` following the repository transfer to the shinkro GitHub organisation.

- `go.mod` — module path
- All `internal/` and `cmd/` Go import paths
- `.goreleaser.yaml` — changelog URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)